### PR TITLE
Changes to align with existing switches

### DIFF
--- a/com.ibm.streamsx.plumbing/com.ibm.streamsx.plumbing.switches/namespace-info.spl
+++ b/com.ibm.streamsx.plumbing/com.ibm.streamsx.plumbing.switches/namespace-info.spl
@@ -19,7 +19,7 @@
  * processing can change an upstream flow through a controlled switch.
  * 
  * [TraceLevelSwitch] is a switch whose state can be changed via the 
- * trace level of the PE it is a part of. 
+ * application trace level of the PE it is a part of. 
  */
 
 namespace com.ibm.streamsx.plumbing.switches;

--- a/com.ibm.streamsx.plumbing/com.ibm.streamsx.plumbing.switches/traceLevelSwitch.spl
+++ b/com.ibm.streamsx.plumbing/com.ibm.streamsx.plumbing.switches/traceLevelSwitch.spl
@@ -5,24 +5,37 @@
 namespace com.ibm.streamsx.plumbing.switches ;
 
 /**
- * Dynamic switch that forwards data based on the trace level. 
- * The trace level at which this operator forwards data is 
- * controlled by the traceThreshold parameter. 
+ * Non-blocking switch set by application trace level. 
+ *
+ * When the switch is closed all tuples on its input port
+ * flow through to its output port unchanged. The switch
+ * is closed if `isTraceable(traceThreshold)` is `true`
+ * or `forceClosed` is `true`, otherwise it is open.
+ *
+ * When the switch is open tuples on its input port are discarded,
+ * thus not blocking any upstream processing.
+ *
+ * A change in the application trace level for the PE hosting
+ * an invocation of `TraceLevelSwitch` dynamically changes
+ * the state of the switch according to the operator's parameters.
  * 
- * @param forceWrite Optional parameter that allows the developer to for the filter to forward input tuples regardless of trace level.  This parameter is false by default. 
- * @param traceThreshold The trace level at which data begins to be forwarded. 
+ * @param forceClosed Optional parameter forces this switch to be closed
+ * regardless of application trace level. When set to `true` the switch
+ * is closed, otherwise its state is set by the trace level.
+ * This parameter is `false` by default. 
+ * @param traceThreshold The application trace level at which this switch closes. Defaults to `TraceLevel.trace`.
  * 
- * @input In Stream to be filtered
- * @output Out Same as input stream, but only forwarded if tracing is at "traceThreshold" or forceWrite is set to true. 
+ * @input IN Input stream to be switched
+ * @output OUT Output stream tuples are submitted to when the switch is closed
  */
-public composite TraceLevelSwitch (input In ; output Out)
+public composite TraceLevelSwitch (input IN ; output OUT)
 {
-	param 
-		expression<boolean> $forceWrite : false;
-		expression<Trace.Level> $traceThreshold : Trace.trace;
-	graph 
-		stream<I> Out = Filter(In as I){
-			param
-				filter : $forceWrite || isTraceable($traceThreshold);
-		}
+  param 
+    expression<boolean> $forceClosed : false;
+    expression<Trace.Level> $traceThreshold : Trace.trace;
+  graph 
+    stream<IN> OUT = Filter(IN) {
+      param
+        filter : $forceClosed || isTraceable($traceThreshold);
+    }
 }


### PR DESCRIPTION
Changed `forceWrite` parameter to `forceClosed`.

Other changes to have same look and feel as existing code.